### PR TITLE
A few fixes

### DIFF
--- a/src/RoboCore_SMW_SX1276M0.cpp
+++ b/src/RoboCore_SMW_SX1276M0.cpp
@@ -1065,7 +1065,7 @@ CommandResponse SMW_SX1276M0::sendX(uint8_t port, const char *data){
   // parse the port
   uint8_t aport = port; // auxiliary variable for <port>
   uint8_t temp[3];
-  uint8_t s;
+
   temp[0] = aport / 100;
   aport %= 100;
   temp[1] = aport / 10;
@@ -1077,8 +1077,7 @@ CommandResponse SMW_SX1276M0::sendX(uint8_t port, const char *data){
   aport = 0; // reset
   for(uint8_t i=0 ; i < 3 ; i++){
     if((temp[i] > 0) || (aport > 0)){
-      s = temp[i] + '0';  // convert to ASCII character
-      sport[index++] = s;
+      sport[index++] = temp[i] + '0';  // convert to ASCII character
     }
     aport += temp[i]; // update (simple)
   }
@@ -1440,7 +1439,7 @@ CommandResponse SMW_SX1276M0::set_NwkSKey(const char *nwkskey){
 void SMW_SX1276M0::setPinReset(int16_t pin_reset){
   _pin_reset = pin_reset;
   pinMode(_pin_reset, OUTPUT);
-  pinMode(_pin_reset, LOW); // Active HIGH
+  digitalWrite(_pin_reset, LOW); // Active HIGH
 }
 
 // --------------------------------------------------

--- a/src/RoboCore_SMW_SX1276M0.cpp
+++ b/src/RoboCore_SMW_SX1276M0.cpp
@@ -1441,7 +1441,7 @@ CommandResponse SMW_SX1276M0::set_NwkSKey(const char *nwkskey){
 //  @param (pin_reset) : the pin to reset the module [int16_t]
 void SMW_SX1276M0::setPinReset(int16_t pin_reset){
   _pin_reset = pin_reset;
-  pinMode(_pin_reset, INPUT);           // There is an internal pull-up, no need to output HIGH
+  pinMode(_pin_reset, INPUT);           // There is an internal pull-down in the DTC114EET1G, no need to output LOW
 }
 
 // --------------------------------------------------


### PR DESCRIPTION
Fixed the following:

1) Reset procedure changed to reflect the official procedure described in the eWBM's eLR100-UL-00 module documentation. Also, the reset circuitry used by Robocore is different.

2) Solved several "narrowing conversion" warnings. While harmless since there is parameter verification ensuring their validity, those warnings were annoying.